### PR TITLE
Vimeo permission param is permission not perms

### DIFF
--- a/lib/omniauth/strategies/vimeo.rb
+++ b/lib/omniauth/strategies/vimeo.rb
@@ -46,7 +46,7 @@ module OmniAuth
       end
 
       def request_phase
-        options[:authorize_params] = {:perms => options[:scope]} if options[:scope]
+        options[:authorize_params] = {:permission => options[:scope]} if options[:scope]
         super
       end
     end


### PR DESCRIPTION
Fixes so you can get write permission by setting
:scope => 'write'
