### PR TITLE
define callback_url to remove query strings

### DIFF
--- a/lib/omniauth/strategies/vimeo.rb
+++ b/lib/omniauth/strategies/vimeo.rb
@@ -30,6 +30,10 @@ module OmniAuth
         }
       end
 
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
       def user_info
         access_token.params['user']
       end


### PR DESCRIPTION
This deals with a change in `omniauth-oauth2` v1.4.0 which switched OmniAuth::Strategies::OAuth2#callback_url to include query strings, while it is used to create `redirect_uri`, which should not include querey strings.

As suggested in intridea/omniauth-oauth2#81 provider gems should to define their own `callback_url`.