### PR TITLE
Update ruby requirement to allow for ruby 3.0

### DIFF
--- a/omniauth-vimeo.gemspec
+++ b/omniauth-vimeo.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '~> 2.0'
+  gem.required_ruby_version = '>= 2.0'
 
   gem.add_dependency 'omniauth-oauth2'
 


### PR DESCRIPTION
I believe this change is all that would be needed to support ruby 3.0.

Would it be possible to make a release and version bump with this change?